### PR TITLE
Abstract LevelDB/RocksDB using namespace alias with ifdef to allow ei…

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -91,7 +91,21 @@ add_subdirectory(config)
 
 # libraries
 add_subdirectory(crypto)
-add_subdirectory(leveldb)
+
+
+# Can change to LevelDB if needed
+find_package(RocksDB) # REQUIRED)
+if (RocksDB_FOUND)
+  message(STATUS "Found RocksDB")
+  message(STATUS "Libs : ${ROCKSDB_LIBRARIES}")
+  add_definitions("-DUSE_ROCKSDB")
+  set(DB_LIBRARIES ${ROCKSDB_LIBRARIES})
+else()
+  message(STATUS "FAILED to FIND RocksDB")
+  add_subdirectory(leveldb)
+  set(DB_LIBRARIES leveldb memenv)
+endif()  
+
 add_subdirectory(secp256k1)
 add_subdirectory(univalue)
 add_subdirectory(coldrewards)
@@ -290,20 +304,19 @@ add_library(server
 	versionbits.cpp
 )
 
-
-
 # This require libevent
 find_package(Event REQUIRED)
 find_package(Miniupnpc REQUIRED)
 
-target_include_directories(server PRIVATE leveldb/helpers/memenv)
+if (NOT RocksDB_FOUND)
+  target_include_directories(server PRIVATE leveldb/helpers/memenv)
+endif()
 
 target_link_libraries(server
 	${EVENT_LIBRARY}
 	${EVENT_PTHREAD_LIBRARY}
 	devaultconsensus
-	leveldb
-	memenv
+  ${DB_LIBRARIES}
   ${MINIUPNP_LIBRARY}
 )
 

--- a/src/wallet/db.h
+++ b/src/wallet/db.h
@@ -125,7 +125,7 @@ public:
 
     void IncrementUpdateCounter();
 
-    std::atomic<unsigned int> nUpdateCounter;
+    std::atomic<unsigned int> nUpdateCounter{};
     unsigned int nLastSeen;
     unsigned int nLastFlushed;
     int64_t nLastWalletUpdate;


### PR DESCRIPTION
…ther to work

With this. CMake builds would use RocksDB if available, Autotools still use LevelDB.
This allows testing/comparison
