### PR TITLE
Password enabled firstrun

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,10 +31,10 @@ endif()
 # Unfortunately setting the -pie linker flag this way required CMake >= 3.14,
 # which is not widely distributed at the time of writing.
 # FIXME: use the POSITION_INDEPENDENT_CODE property instead
-# set(CMAKE_POSITION_INDEPENDENT_CODE ON) # for all targets
 if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Windows")
-	add_compiler_flag(-fPIC -fPIE)
-	add_linker_flag(-pie)
+  set(CMAKE_POSITION_INDEPENDENT_CODE ON) # for all targets
+	#add_compiler_flag(-fPIC -fPIE)
+	#add_linker_flag(-pie)
 endif()
 
 # Enable warning
@@ -137,6 +137,9 @@ source_group("PolicyHeaders" FILES ${POLICY_HEADERS})
 file(GLOB SCRIPT_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/script/*.h)
 source_group("ScriptHeaders" FILES ${SCRIPT_HEADERS})
 
+file(GLOB SUPPORT_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/support/*.h ${CMAKE_CURRENT_SOURCE_DIR}/support/allocators/*.h)
+source_group("SupportHeaders" FILES ${SUPPORT_HEADERS})
+
 # Because the Bitcoin ABc source code is disorganised, we
 # end up with a bunch of libraries without any aparent
 # cohesive structure. This is inherited from Bitcoin Core
@@ -145,6 +148,7 @@ source_group("ScriptHeaders" FILES ${SCRIPT_HEADERS})
 
 # Various completely unrelated features shared by all executables.
 add_library(util
+  ${SUPPORT_HEADERS}
 	chainparamsbase.cpp
 	clientversion.cpp
 	compat/glibc_sanity.cpp

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -54,6 +54,28 @@ void WaitForShutdown() {
     Interrupt();
 }
 
+void getPassphrase(SecureString& walletPassphrase) {
+  std::cout << "Enter a New Encryption password\n";
+  SecureString pass1;
+  SecureString pass2;
+  char c='0';
+  do {
+    while (c != '\n') {
+      std::cin.get(c);
+      std::cout << "*" << std::flush;
+      pass1.push_back(c);
+    }
+    c = '0';
+    std::cout << "Confirm password\n";
+    while (c != '\n') {
+      std::cin.get(c);
+      std::cout << "*" << std::flush;
+      pass2.push_back(c);
+    }
+  } while (pass1 != pass2);
+  walletPassphrase   = pass1;
+}
+
 //////////////////////////////////////////////////////////////////////////////
 //
 // Start
@@ -68,7 +90,6 @@ bool AppInit(int argc, char *argv[]) {
 
     bool fRet = false;
     SecureString walletPassphrase;
-
     //
     // Parameters
     //
@@ -97,28 +118,6 @@ bool AppInit(int argc, char *argv[]) {
     }
 
     try {
-        if (!CheckIfWalletDirExists(false)) {
-          std::cout << "Enter a New Encryption password\n";
-          SecureString pass1;
-          SecureString pass2;
-          char c='0';
-          do {
-            while (c != '\n') {
-              std::cin.get(c);
-              std::cout << "*" << std::flush;
-              pass1.push_back(c);
-            }
-            c = '0';
-            std::cout << "Confirm password\n";
-            while (c != '\n') {
-              std::cin.get(c);
-              std::cout << "*" << std::flush;
-              pass2.push_back(c);
-            }
-          } while (pass1 != pass2);
-          walletPassphrase   = pass1;
-        }
-
       
         if (!fs::is_directory(GetDataDir(false))) {
             fprintf(stderr,
@@ -140,6 +139,11 @@ bool AppInit(int argc, char *argv[]) {
             fprintf(stderr, "Error: %s\n", e.what());
             return false;
         }
+      
+        if (!CheckIfWalletDirExists(true)) {
+          getPassphrase(walletPassphrase);
+        }
+
 
         // Error out when loose non-argument tokens are encountered on command
         // line

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -140,11 +140,6 @@ bool AppInit(int argc, char *argv[]) {
             return false;
         }
       
-        if (!CheckIfWalletDirExists(true)) {
-          getPassphrase(walletPassphrase);
-        }
-
-
         // Error out when loose non-argument tokens are encountered on command
         // line
         for (int i = 1; i < argc; i++) {
@@ -173,6 +168,12 @@ bool AppInit(int argc, char *argv[]) {
             // up on console
             exit(1);
         }
+      
+      if (!g_wallet_init_interface->CheckIfWalletExists(config.GetChainParams())) {
+        //std::cout << "Stop here no wallet found\n!";
+        getPassphrase(walletPassphrase);
+      }
+
         if (!AppInitSanityChecks()) {
             // InitError will have been called with detailed error, which ends
             // up on console

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -20,7 +20,8 @@
 #include "util.h"
 #include "utilstrencodings.h"
 #include "walletinitinterface.h"
-
+#include "support/allocators/secure.h"
+#include <cstdint>
 #include <boost/thread.hpp>
 
 #include <cstdio>
@@ -66,6 +67,7 @@ bool AppInit(int argc, char *argv[]) {
     HTTPRPCRequestProcessor httpRPCRequestProcessor(config, rpcServer);
 
     bool fRet = false;
+    SecureString walletPassphrase;
 
     //
     // Parameters
@@ -95,6 +97,30 @@ bool AppInit(int argc, char *argv[]) {
     }
 
     try {
+        if (!CheckIfWalletDirExists(false)) {
+          std::cout << "Enter a New Encryption password\n";
+          SecureString pass1;
+          SecureString pass2;
+          char c='0';
+          do {
+            while (c != '\n') {
+              std::cin.get(c);
+              std::cout << "*" << std::flush;
+              pass1.push_back(c);
+            }
+            c = '0';
+            std::cout << "Confirm password\n";
+            while (c != '\n') {
+              std::cin.get(c);
+              std::cout << "*" << std::flush;
+              pass2.push_back(c);
+            }
+          } while (pass1 != pass2);
+          walletPassphrase   = "123";
+          exit(0);
+        }
+
+      
         if (!fs::is_directory(GetDataDir(false))) {
             fprintf(stderr,
                     "Error: Specified data directory \"%s\" does not exist.\n",
@@ -173,7 +199,7 @@ bool AppInit(int argc, char *argv[]) {
             // If locking the data directory failed, exit immediately
             exit(EXIT_FAILURE);
         }
-        fRet = AppInitMain(config, httpRPCRequestProcessor);
+        fRet = AppInitMain(config, httpRPCRequestProcessor, walletPassphrase);
     } catch (const std::exception &e) {
         PrintExceptionContinue(&e, "AppInit()");
     } catch (...) {

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -116,8 +116,7 @@ bool AppInit(int argc, char *argv[]) {
               pass2.push_back(c);
             }
           } while (pass1 != pass2);
-          walletPassphrase   = "123";
-          exit(0);
+          walletPassphrase   = pass1;
         }
 
       

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -63,14 +63,14 @@ void getPassphrase(SecureString& walletPassphrase) {
     while (c != '\n') {
       std::cin.get(c);
       std::cout << "*" << std::flush;
-      pass1.push_back(c);
+      if (c != '\n') pass1.push_back(c);
     }
     c = '0';
     std::cout << "Confirm password\n";
     while (c != '\n') {
       std::cin.get(c);
       std::cout << "*" << std::flush;
-      pass2.push_back(c);
+      if (c != '\n') pass2.push_back(c);
     }
   } while (pass1 != pass2);
   walletPassphrase   = pass1;

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -55,7 +55,7 @@ void WaitForShutdown() {
 }
 
 void getPassphrase(SecureString& walletPassphrase) {
-  std::cout << "Enter a New Encryption password\n";
+  std::cout << "Enter a Wallet Encryption password\n";
   SecureString pass1;
   SecureString pass2;
   char c='0';

--- a/src/coldrewards/rewards_calculation.cpp
+++ b/src/coldrewards/rewards_calculation.cpp
@@ -4,6 +4,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "chain.h"
+#include "config/bitcoin-config.h"
 #include "rewards_calculation.h"
 
 Amount CalculateReward(const Consensus::Params &consensusParams, int Height, int HeightDiff, Amount balance) {

--- a/src/coldrewards/rewards_calculation.cpp
+++ b/src/coldrewards/rewards_calculation.cpp
@@ -3,9 +3,11 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include "chain.h"
+// clang-format off
 #include "config/bitcoin-config.h"
+#include "chain.h"
 #include "rewards_calculation.h"
+// clang-format on
 
 Amount CalculateReward(const Consensus::Params &consensusParams, int Height, int HeightDiff, Amount balance) {
   size_t year_number = Height/consensusParams.nBlocksPerYear;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1778,7 +1778,7 @@ bool AppInitLockDataDirectory() {
 }
 
 bool AppInitMain(Config &config,
-                 HTTPRPCRequestProcessor &httpRPCRequestProcessor) {
+                 HTTPRPCRequestProcessor &httpRPCRequestProcessor, const SecureString& walletPassphrase) {
     // Step 4a: application initialization
     const CChainParams &chainparams = config.GetChainParams();
 
@@ -2273,7 +2273,7 @@ bool AppInitMain(Config &config,
 
 
     // Step 8: load wallet
-    if (!g_wallet_init_interface->Open(chainparams)) {
+    if (!g_wallet_init_interface->Open(chainparams, walletPassphrase)) {
         return false;
     }
 

--- a/src/init.h
+++ b/src/init.h
@@ -4,11 +4,12 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_INIT_H
-#define BITCOIN_INIT_H
+#pragma once
 
 #include <memory>
 #include <string>
+#include "support/allocators/secure.h"
+
 
 class Config;
 class CScheduler;
@@ -71,7 +72,8 @@ bool AppInitLockDataDirectory();
  * AppInitLockDataDirectory should have been called.
  */
 bool AppInitMain(Config &config,
-                 HTTPRPCRequestProcessor &httpRPCRequestProcessor);
+                 HTTPRPCRequestProcessor &httpRPCRequestProcessor,
+                 const SecureString& walletPassphrase);
 
 /** The help message mode determines what help message to show */
 enum HelpMessageMode { HMM_BITCOIND, HMM_BITCOIN_QT };
@@ -81,4 +83,3 @@ std::string HelpMessage(HelpMessageMode mode);
 /** Returns licensing information (for -version) */
 std::string LicenseInfo();
 
-#endif // BITCOIN_INIT_H

--- a/src/keystore.cpp
+++ b/src/keystore.cpp
@@ -146,3 +146,8 @@ bool CBasicKeyStore::HaveWatchOnly() const {
     LOCK(cs_KeyStore);
     return (!setWatchOnly.empty());
 }
+bool CBasicKeyStore::GetHDChain(CHDChain& hdChainRet) const
+{
+    hdChainRet = hdChain;
+    return !hdChain.IsNull();
+}

--- a/src/keystore.h
+++ b/src/keystore.h
@@ -80,6 +80,8 @@ public:
     virtual bool RemoveWatchOnly(const CScript &dest) override;
     virtual bool HaveWatchOnly(const CScript &dest) const override;
     virtual bool HaveWatchOnly() const override;
+    virtual bool GetHDChain(CHDChain& hdChainRet) const;
+
 };
 
 typedef std::vector<uint8_t, secure_allocator<uint8_t>> CKeyingMaterial;

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -153,6 +153,7 @@ add_library(bitcoin-qt-base
 	splashscreen.cpp
 	trafficgraphwidget.cpp
 	utilitydialog.cpp
+  dvtui.cpp
 
 	# Handle ui files
 	${UI_GENERATED_HEADERS}

--- a/src/qt/askpassphrasedialog.cpp
+++ b/src/qt/askpassphrasedialog.cpp
@@ -40,15 +40,6 @@ AskPassphraseDialog::AskPassphraseDialog(Mode _mode, QWidget *parent)
     ui->buttonBox->button(QDialogButtonBox::Cancel)->setIcon(QIcon());
 
     switch (mode) {
-        case Encrypt: // Ask passphrase x2
-            ui->warningLabel->setText(
-                tr("Enter the new passphrase to the wallet.<br/>Please use a "
-                   "passphrase of <b>ten or more random characters</b>, or "
-                   "<b>eight or more words</b>."));
-            ui->passLabel1->hide();
-            ui->passEdit1->hide();
-            setWindowTitle(tr("Encrypt wallet"));
-            break;
         case Unlock: // Ask passphrase
             ui->warningLabel->setText(tr("This operation needs your wallet "
                                          "passphrase to unlock the wallet."));
@@ -57,15 +48,6 @@ AskPassphraseDialog::AskPassphraseDialog(Mode _mode, QWidget *parent)
             ui->passLabel3->hide();
             ui->passEdit3->hide();
             setWindowTitle(tr("Unlock wallet"));
-            break;
-        case Decrypt: // Ask passphrase
-            ui->warningLabel->setText(tr("This operation needs your wallet "
-                                         "passphrase to decrypt the wallet."));
-            ui->passLabel2->hide();
-            ui->passEdit2->hide();
-            ui->passLabel3->hide();
-            ui->passEdit3->hide();
-            setWindowTitle(tr("Decrypt wallet"));
             break;
         case ChangePass: // Ask old passphrase + new passphrase x2
             setWindowTitle(tr("Change passphrase"));
@@ -107,58 +89,6 @@ void AskPassphraseDialog::accept() {
     secureClearPassFields();
 
     switch (mode) {
-        case Encrypt: {
-            if (newpass1.empty() || newpass2.empty()) {
-                // Cannot encrypt with empty passphrase
-                break;
-            }
-            QMessageBox::StandardButton retval = QMessageBox::question(
-                this, tr("Confirm wallet encryption"),
-                tr("Warning: If you encrypt your wallet and lose your "
-                   "passphrase, you will <b>LOSE ALL OF YOUR BITCOINS</b>!") +
-                    "<br><br>" +
-                    tr("Are you sure you wish to encrypt your wallet?"),
-                QMessageBox::Yes | QMessageBox::Cancel, QMessageBox::Cancel);
-            if (retval == QMessageBox::Yes) {
-                if (newpass1 == newpass2) {
-                    if (model->setWalletEncrypted(true, newpass1)) {
-                        QMessageBox::warning(
-                            this, tr("Wallet encrypted"),
-                            "<qt>" +
-                                tr("%1 will close now to finish the encryption "
-                                   "process. "
-                                   "Remember that encrypting your wallet "
-                                   "cannot fully protect "
-                                   "your bitcoins from being stolen by malware "
-                                   "infecting your computer.")
-                                    .arg(tr(PACKAGE_NAME)) +
-                                "<br><br><b>" +
-                                tr("IMPORTANT: Any previous backups you have "
-                                   "made of your wallet file "
-                                   "should be replaced with the newly "
-                                   "generated, encrypted wallet file. "
-                                   "For security reasons, previous backups of "
-                                   "the unencrypted wallet file "
-                                   "will become useless as soon as you start "
-                                   "using the new, encrypted wallet.") +
-                                "</b></qt>");
-                        QApplication::quit();
-                    } else {
-                        QMessageBox::critical(
-                            this, tr("Wallet encryption failed"),
-                            tr("Wallet encryption failed due to an internal "
-                               "error. Your wallet was not encrypted."));
-                    }
-                    QDialog::accept(); // Success
-                } else {
-                    QMessageBox::critical(
-                        this, tr("Wallet encryption failed"),
-                        tr("The supplied passphrases do not match."));
-                }
-            } else {
-                QDialog::reject(); // Cancelled
-            }
-        } break;
         case Unlock:
             if (!model->setWalletLocked(false, oldpass)) {
                 QMessageBox::critical(this, tr("Wallet unlock failed"),
@@ -168,16 +98,7 @@ void AskPassphraseDialog::accept() {
                 QDialog::accept(); // Success
             }
             break;
-        case Decrypt:
-            if (!model->setWalletEncrypted(false, oldpass)) {
-                QMessageBox::critical(this, tr("Wallet decryption failed"),
-                                      tr("The passphrase entered for the "
-                                         "wallet decryption was incorrect."));
-            } else {
-                QDialog::accept(); // Success
-            }
-            break;
-        case ChangePass:
+         case ChangePass:
             if (newpass1 == newpass2) {
                 if (model->changePassphrase(oldpass, newpass1)) {
                     QMessageBox::information(
@@ -203,12 +124,7 @@ void AskPassphraseDialog::textChanged() {
     // Validate input, set Ok button to enabled when acceptable
     bool acceptable = false;
     switch (mode) {
-        case Encrypt: // New passphrase x2
-            acceptable = !ui->passEdit2->text().isEmpty() &&
-                         !ui->passEdit3->text().isEmpty();
-            break;
         case Unlock: // Old passphrase x1
-        case Decrypt:
             acceptable = !ui->passEdit1->text().isEmpty();
             break;
         case ChangePass: // Old passphrase x1, new passphrase x2

--- a/src/qt/askpassphrasedialog.h
+++ b/src/qt/askpassphrasedialog.h
@@ -21,10 +21,8 @@ class AskPassphraseDialog : public QDialog {
 
 public:
     enum Mode {
-        Encrypt,    /**< Ask passphrase twice and encrypt */
         Unlock,     /**< Ask passphrase and unlock */
-        ChangePass, /**< Ask old passphrase + new passphrase twice */
-        Decrypt     /**< Ask passphrase and decrypt wallet */
+        ChangePass  /**< Ask old passphrase + new passphrase twice */
     };
 
     explicit AskPassphraseDialog(Mode mode, QWidget *parent);

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -209,7 +209,7 @@ public:
     /// Create options model
     void createOptionsModel(bool resetSettings);
     /// Create main window
-    void createWindow(const Config *, const NetworkStyle *networkStyle);
+    bool createWindow(const Config *, const NetworkStyle *networkStyle);
     /// Create splash screen
     void createSplashScreen(const NetworkStyle *networkStyle);
     /// Get wallet password from user for Wallet Encryption
@@ -377,15 +377,17 @@ void BitcoinApplication::setupPassword(SecureString& password) {
   }
 }
 
-void BitcoinApplication::createWindow(const Config *config,
+bool BitcoinApplication::createWindow(const Config *config,
                                       const NetworkStyle *networkStyle) {
 
     setupPassword(pss);
+    if (pss.empty()) return false;
     window = new BitcoinGUI(config, platformStyle, networkStyle, 0);
 
     pollShutdownTimer = new QTimer(window);
     connect(pollShutdownTimer, SIGNAL(timeout()), window,
             SLOT(detectShutdown()));
+    return true;
 }
 
 void BitcoinApplication::createSplashScreen(const NetworkStyle *networkStyle) {
@@ -764,7 +766,9 @@ int main(int argc, char *argv[]) {
     HTTPRPCRequestProcessor httpRPCRequestProcessor(config, rpcServer);
 
     try {
-        app.createWindow(&config, networkStyle.data());
+        if (!app.createWindow(&config, networkStyle.data())) {
+            return EXIT_FAILURE;
+        }
         // Perform base initialization before spinning up
         // initialization/shutdown thread. This is acceptable because this
         // function only contains steps that are quick to execute, so the GUI

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -374,7 +374,6 @@ void BitcoinApplication::setupPassword(SecureString& password) {
     SetPassphraseDialog dlg(0);
     dlg.exec();
     password = dlg.getPassword();
-    std::cout << "Got " << password << "\n";
   }
 }
 

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -507,7 +507,6 @@ void BitcoinApplication::initializeResult(bool success) {
         WalletModel *const walletModel =
             new WalletModel(platformStyle, pwallet, optionsModel);
 
-        walletModel->setWalletEncrypted(true, pss);
         window->addWallet(walletModel);
         if (fFirstWallet) {
             window->setCurrentWallet(walletModel->getWalletName());

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -367,7 +367,7 @@ bool BitcoinApplication::setupPassword(SecureString& password) {
         if (fs::exists(walletFile)) return true;
     }
   }
-  if (CheckIfWalletDirExists()) return true;
+  if (CheckIfWalletDatExists()) return true;
   
   SetPassphraseDialog dlg(0);
   dlg.exec();

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -289,12 +289,6 @@ void BitcoinGUI::createActions() {
                     tr("&Show / Hide"), this);
     toggleHideAction->setStatusTip(tr("Show or hide the main Window"));
 
-    encryptWalletAction =
-        new QAction(platformStyle->TextColorIcon(":/icons/lock_closed"),
-                    tr("&Encrypt Wallet..."), this);
-    encryptWalletAction->setStatusTip(
-        tr("Encrypt the private keys that belong to your wallet"));
-    encryptWalletAction->setCheckable(true);
     backupWalletAction =
         new QAction(platformStyle->TextColorIcon(":/icons/filesave"),
                     tr("&Backup Wallet..."), this);
@@ -364,9 +358,7 @@ void BitcoinGUI::createActions() {
 
 #ifdef ENABLE_WALLET
     if (walletFrame) {
-        connect(encryptWalletAction, SIGNAL(triggered(bool)), walletFrame,
-                SLOT(encryptWallet(bool)));
-        connect(backupWalletAction, SIGNAL(triggered()), walletFrame,
+         connect(backupWalletAction, SIGNAL(triggered()), walletFrame,
                 SLOT(backupWallet()));
         connect(changePassphraseAction, SIGNAL(triggered()), walletFrame,
                 SLOT(changePassphrase()));
@@ -414,7 +406,6 @@ void BitcoinGUI::createMenuBar() {
 
     QMenu *settings = appMenuBar->addMenu(tr("&Settings"));
     if (walletFrame) {
-        settings->addAction(encryptWalletAction);
         settings->addAction(changePassphraseAction);
         settings->addSeparator();
     }
@@ -633,7 +624,6 @@ void BitcoinGUI::setWalletActionsEnabled(bool enabled) {
     sendCoinsMenuAction->setEnabled(enabled);
     receiveCoinsAction->setEnabled(enabled);
     receiveCoinsMenuAction->setEnabled(enabled);
-    encryptWalletAction->setEnabled(enabled);
     backupWalletAction->setEnabled(enabled);
     changePassphraseAction->setEnabled(enabled);
     signMessageAction->setEnabled(enabled);
@@ -1140,9 +1130,7 @@ void BitcoinGUI::setEncryptionStatus(int status) {
     switch (status) {
         case WalletModel::Unencrypted:
             labelWalletEncryptionIcon->hide();
-            encryptWalletAction->setChecked(false);
             changePassphraseAction->setEnabled(false);
-            encryptWalletAction->setEnabled(true);
             break;
         case WalletModel::Unlocked:
             labelWalletEncryptionIcon->show();
@@ -1151,10 +1139,7 @@ void BitcoinGUI::setEncryptionStatus(int status) {
                     .pixmap(STATUSBAR_ICONSIZE, STATUSBAR_ICONSIZE));
             labelWalletEncryptionIcon->setToolTip(
                 tr("Wallet is <b>encrypted</b> and currently <b>unlocked</b>"));
-            encryptWalletAction->setChecked(true);
             changePassphraseAction->setEnabled(true);
-            encryptWalletAction->setEnabled(
-                false); // TODO: decrypt currently not supported
             break;
         case WalletModel::Locked:
             labelWalletEncryptionIcon->show();
@@ -1163,10 +1148,7 @@ void BitcoinGUI::setEncryptionStatus(int status) {
                     .pixmap(STATUSBAR_ICONSIZE, STATUSBAR_ICONSIZE));
             labelWalletEncryptionIcon->setToolTip(
                 tr("Wallet is <b>encrypted</b> and currently <b>locked</b>"));
-            encryptWalletAction->setChecked(true);
             changePassphraseAction->setEnabled(true);
-            encryptWalletAction->setEnabled(
-                false); // TODO: decrypt currently not supported
             break;
     }
 }

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -119,7 +119,6 @@ private:
     QAction *receiveCoinsMenuAction = nullptr;
     QAction *optionsAction = nullptr;
     QAction *toggleHideAction = nullptr;
-    QAction *encryptWalletAction = nullptr;
     QAction *backupWalletAction = nullptr;
     QAction *changePassphraseAction = nullptr;
     QAction *aboutQtAction = nullptr;

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -10,6 +10,7 @@
 #endif
 
 #include "amount.h"
+#include "support/allocators/secure.h"
 #include "dvtui.h"
 
 #include <QLabel>

--- a/src/qt/setpassphrasedialog.cpp
+++ b/src/qt/setpassphrasedialog.cpp
@@ -81,7 +81,7 @@ void SetPassphraseDialog::accept() {
     }
     if (newpass1 == newpass2) {
         password = newpass1;
-        QMessageBox::warning(this, tr("Success"), tr("Password verified").arg(tr(PACKAGE_NAME)) + "<br><br><b></b></qt>");
+        //QMessageBox::warning(this, tr("Success"), tr("Password verified").arg(tr(PACKAGE_NAME)) + "<br><br><b></b></qt>");
         QApplication::quit();
     } else {
         QMessageBox::critical(this, tr("failed"), tr("The supplied passphrases do not match."));

--- a/src/qt/setpassphrasedialog.h
+++ b/src/qt/setpassphrasedialog.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <QDialog>
+#include "support/allocators/secure.h"
 
 class CWallet;
 
@@ -22,11 +23,11 @@ public:
     ~SetPassphraseDialog();
 
     void accept() override;
-    std::string getPassword() { return password; }
+    SecureString getPassword() { return password; }
 
 private:
     Ui::SetPassphraseDialog *ui;
-    std::string password;
+    SecureString password;
     bool fCapsLock;
                   
 

--- a/src/qt/splashscreen.cpp
+++ b/src/qt/splashscreen.cpp
@@ -48,7 +48,6 @@ SplashScreen::SplashScreen(Qt::WindowFlags f, const NetworkStyle *networkStyle)
     pixmap = QPixmap(splashSize);
 
     // set reference point, paddings relative to size
-    int paddingRight            = 50;
     int vSpace                  = 10;
     int paddingTop              = 320*0.65 - vSpace;
     //float iconHeight              = 86;

--- a/src/qt/walletframe.cpp
+++ b/src/qt/walletframe.cpp
@@ -140,11 +140,6 @@ void WalletFrame::gotoVerifyMessageTab(QString addr) {
     if (walletView) walletView->gotoVerifyMessageTab(addr);
 }
 
-void WalletFrame::encryptWallet(bool status) {
-    WalletView *walletView = currentWalletView();
-    if (walletView) walletView->encryptWallet(status);
-}
-
 void WalletFrame::backupWallet() {
     WalletView *walletView = currentWalletView();
     if (walletView) walletView->backupWallet();

--- a/src/qt/walletframe.h
+++ b/src/qt/walletframe.h
@@ -80,8 +80,6 @@ public Q_SLOTS:
     /** Show Sign/Verify Message dialog and switch to verify message tab */
     void gotoVerifyMessageTab(QString addr = "");
 
-    /** Encrypt the wallet */
-    void encryptWallet(bool status);
     /** Backup the wallet */
     void backupWallet();
     /** Change encrypted wallet passphrase */

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -358,17 +358,6 @@ WalletModel::EncryptionStatus WalletModel::getEncryptionStatus() const {
     }
 }
 
-bool WalletModel::setWalletEncrypted(bool encrypted,
-                                     const SecureString &passphrase) {
-    if (encrypted) {
-        // Encrypt
-        return wallet->EncryptWallet(passphrase);
-    } else {
-        // Decrypt -- TODO; not supported yet
-        return false;
-    }
-}
-
 bool WalletModel::setWalletLocked(bool locked, const SecureString &passPhrase) {
     if (locked) {
         // Lock

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -153,8 +153,6 @@ public:
     // Send coins to a list of recipients
     SendCoinsReturn sendCoins(WalletModelTransaction &transaction);
 
-    // Wallet encryption
-    bool setWalletEncrypted(bool encrypted, const SecureString &passphrase);
     // Passphrase only needed when unlocking
     bool setWalletLocked(bool locked,
                          const SecureString &passPhrase = SecureString());

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -267,20 +267,6 @@ void WalletView::updateEncryptionStatus() {
     Q_EMIT encryptionStatusChanged();
 }
 
-void WalletView::encryptWallet(bool status) {
-    if (!walletModel) {
-        return;
-    }
-
-    AskPassphraseDialog dlg(status ? AskPassphraseDialog::Encrypt
-                                   : AskPassphraseDialog::Decrypt,
-                            this);
-    dlg.setModel(walletModel);
-    dlg.exec();
-
-    updateEncryptionStatus();
-}
-
 void WalletView::backupWallet() {
     QString filename =
         GUIUtil::getSaveFileName(this, tr("Backup Wallet"), QString(),

--- a/src/qt/walletview.h
+++ b/src/qt/walletview.h
@@ -98,8 +98,6 @@ public Q_SLOTS:
      * parent item.
      */
     void processNewTransaction(const QModelIndex &parent, int start, int end);
-    /** Encrypt the wallet */
-    void encryptWallet(bool status);
     /** Backup the wallet */
     void backupWallet();
     /** Change encrypted wallet passphrase */

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -278,7 +278,8 @@ static UniValue validateaddress(const Config &config,
               if (it != pwallet->mapKeyMetadata.end()) meta = &it->second;
               // inside if
               if (meta) {
-                  CHDChain hdChain = pwallet->GetHDChain();
+                  CHDChain hdChain;
+                  pwallet->GetHDChain(hdChain);
                   if (!key_id->IsNull() && pwallet->mapHdPubKeys.count(*key_id)) {
                   ret.push_back(Pair("hdkeypath", pwallet->mapHdPubKeys[*key_id].GetKeyPath()));
                   ret.push_back(Pair("hdchainid", hdChain.GetID().GetHex()));

--- a/src/support/allocators/secure.h
+++ b/src/support/allocators/secure.h
@@ -1,15 +1,16 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2016 The Bitcoin Core developers
+// Copyright (c) 2019 The DeVault developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_SUPPORT_ALLOCATORS_SECURE_H
-#define BITCOIN_SUPPORT_ALLOCATORS_SECURE_H
+#pragma once
 
 #include "support/cleanse.h"
 #include "support/lockedpool.h"
 
 #include <string>
+#include <vector>
 
 //
 // Allocator that locks its contents from being paged
@@ -51,4 +52,4 @@ template <typename T> struct secure_allocator : public std::allocator<T> {
 typedef std::basic_string<char, std::char_traits<char>, secure_allocator<char>>
     SecureString;
 
-#endif // BITCOIN_SUPPORT_ALLOCATORS_SECURE_H
+typedef std::vector<unsigned char, secure_allocator<unsigned char>> SecureVector;

--- a/src/ui_interface.cpp
+++ b/src/ui_interface.cpp
@@ -13,7 +13,7 @@ bool InitError(const std::string &str) {
 }
 
 bool ShowSeedPhrase(const std::string &str) {
-    uiInterface.ThreadSafeMessageBox(str, "", CClientUIInterface::MSG_WARNING);
+    uiInterface.ThreadSafeMessageBox(str, "", CClientUIInterface::MSG_SEED);
     return false;
 }
 

--- a/src/ui_interface.h
+++ b/src/ui_interface.h
@@ -70,6 +70,7 @@ public:
         /** Predefined combinations for certain default usage cases */
         MSG_INFORMATION = ICON_INFORMATION,
         MSG_WARNING = (ICON_WARNING | BTN_OK | MODAL),
+        MSG_SEED = (ICON_WARNING | BTN_OK | MODAL | SECURE),
         MSG_ERROR = (ICON_ERROR | BTN_OK | MODAL)
     };
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -672,6 +672,35 @@ const fs::path &GetDataDir(bool fNetSpecific) {
     return path;
 }
 
+const fs::path GetDataDirNoCreate(bool fNetSpecific) {
+  // copy instead of reference
+  fs::path path = fNetSpecific ? pathCachedNetSpecific : pathCached;
+  
+  // This can be called during exceptions by LogPrintf(), so we cache the
+  // value so we don't have to do memory allocations after that.
+  if (!path.empty()) {
+    return path;
+  }
+  
+  if (gArgs.IsArgSet("-datadir")) {
+    path = fs::system_complete(gArgs.GetArg("-datadir", ""));
+    if (!fs::is_directory(path)) {
+      path = "";
+      return path;
+    }
+  } else {
+    path = GetDefaultDataDir();
+  }
+  
+  if (fNetSpecific) {
+    path /= BaseParams().DataDir();
+  }
+  
+  path /= "wallets";
+  
+  return path;
+}
+
 void ClearDatadirCache() {
     LOCK(csPathCached);
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -620,7 +620,7 @@ static fs::path pathCached;
 static fs::path pathCachedNetSpecific;
 static CCriticalSection csPathCached;
 
-bool CheckIfWalletDirExists(bool fNetSpecific) {
+bool CheckIfWalletDatExists(bool fNetSpecific) {
   fs::path path;
   if (gArgs.IsArgSet("-datadir")) {
     path = fs::system_complete(gArgs.GetArg("-datadir", ""));
@@ -636,6 +636,7 @@ bool CheckIfWalletDirExists(bool fNetSpecific) {
   }
   
   path /= "wallets";
+  path /= "wallet.dat";
   return fs::exists(path);
 }
 
@@ -664,10 +665,9 @@ const fs::path &GetDataDir(bool fNetSpecific) {
         path /= BaseParams().DataDir();
     }
 
-    if (fs::create_directories(path)) {
-        // This is the first run, create wallets subdirectory too
-        fs::create_directories(path / "wallets");
-    }
+    fs::create_directories(path);
+    // Make sure this wallets subdirectory exists too
+    fs::create_directories(path / "wallets");
 
     return path;
 }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -635,7 +635,8 @@ bool CheckIfWalletDirExists(bool fNetSpecific) {
     path /= BaseParams().DataDir();
   }
   
-  return fs::exists(path / "wallets");
+  path /= "wallets";
+  return fs::exists(path);
 }
 
 const fs::path &GetDataDir(bool fNetSpecific) {

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -672,9 +672,9 @@ const fs::path &GetDataDir(bool fNetSpecific) {
     return path;
 }
 
-const fs::path GetDataDirNoCreate(bool fNetSpecific) {
+const fs::path GetDataDirNoCreate() {
   // copy instead of reference
-  fs::path path = fNetSpecific ? pathCachedNetSpecific : pathCached;
+  fs::path path = pathCachedNetSpecific;
   
   // This can be called during exceptions by LogPrintf(), so we cache the
   // value so we don't have to do memory allocations after that.
@@ -691,13 +691,6 @@ const fs::path GetDataDirNoCreate(bool fNetSpecific) {
   } else {
     path = GetDefaultDataDir();
   }
-  
-  if (fNetSpecific) {
-    path /= BaseParams().DataDir();
-  }
-  
-  path /= "wallets";
-  
   return path;
 }
 

--- a/src/util.h
+++ b/src/util.h
@@ -76,7 +76,7 @@ bool TryCreateDirectories(const fs::path &p);
 fs::path GetDefaultDataDir();
 const fs::path &GetDataDir(bool fNetSpecific = true);
 const fs::path GetDataDirNoCreate();
-bool CheckIfWalletDirExists(bool fNetSpecific = true);
+bool CheckIfWalletDatExists(bool fNetSpecific = true);
 void ClearDatadirCache();
 fs::path GetConfigFile(const std::string &confPath);
 #ifndef WIN32

--- a/src/util.h
+++ b/src/util.h
@@ -75,6 +75,7 @@ bool RenameOver(fs::path src, fs::path dest);
 bool TryCreateDirectories(const fs::path &p);
 fs::path GetDefaultDataDir();
 const fs::path &GetDataDir(bool fNetSpecific = true);
+const fs::path GetDataDirNoCreate(bool fNetSpecific = true);
 bool CheckIfWalletDirExists(bool fNetSpecific = true);
 void ClearDatadirCache();
 fs::path GetConfigFile(const std::string &confPath);

--- a/src/util.h
+++ b/src/util.h
@@ -75,7 +75,7 @@ bool RenameOver(fs::path src, fs::path dest);
 bool TryCreateDirectories(const fs::path &p);
 fs::path GetDefaultDataDir();
 const fs::path &GetDataDir(bool fNetSpecific = true);
-const fs::path GetDataDirNoCreate(bool fNetSpecific = true);
+const fs::path GetDataDirNoCreate();
 bool CheckIfWalletDirExists(bool fNetSpecific = true);
 void ClearDatadirCache();
 fs::path GetConfigFile(const std::string &confPath);

--- a/src/wallet/crypter.h
+++ b/src/wallet/crypter.h
@@ -2,9 +2,9 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_WALLET_CRYPTER_H
-#define BITCOIN_WALLET_CRYPTER_H
+#pragma once
 
+#include "hdchain.h"
 #include "keystore.h"
 #include "serialize.h"
 #include "support/allocators/secure.h"
@@ -119,6 +119,7 @@ public:
 class CCryptoKeyStore : public CBasicKeyStore {
 private:
     CKeyingMaterial vMasterKey;
+    CHDChain cryptedHDChain;
 
     //! if fUseCrypto is true, mapKeys must be empty
     //! if fUseCrypto is false, vMasterKey must be empty
@@ -133,10 +134,13 @@ protected:
     //! will encrypt previously unencrypted keys
     bool EncryptKeys(CKeyingMaterial &vMasterKeyIn);
     bool SetHDChain(const CHDChain& chain);
-
+    bool EncryptHDChain(const CKeyingMaterial& vMasterKeyIn);
+    bool DecryptHDChain(CHDChain& hdChainRet) const;
+    bool SetCryptedHDChain(const CHDChain& chain);
     bool Unlock(const CKeyingMaterial &vMasterKeyIn);
-    CryptedKeyMap mapCryptedKeys;
 
+    CryptedKeyMap mapCryptedKeys;
+    
 public:
     CCryptoKeyStore()
         : fUseCrypto(false), fDecryptionThoroughlyChecked(false) {}
@@ -152,6 +156,8 @@ public:
     bool GetKey(const CKeyID &address, CKey &keyOut) const override;
     bool GetPubKey(const CKeyID &address, CPubKey &vchPubKeyOut) const override;
     std::set<CKeyID> GetKeys() const override;
+    virtual bool GetHDChain(CHDChain& hdChainRet) const override;
+
 
     /**
      * Wallet status (encrypted, locked) changed.
@@ -160,4 +166,5 @@ public:
     boost::signals2::signal<void(CCryptoKeyStore *wallet)> NotifyStatusChanged;
 };
 
-#endif // BITCOIN_WALLET_CRYPTER_H
+
+

--- a/src/wallet/hdchain.cpp
+++ b/src/wallet/hdchain.cpp
@@ -19,6 +19,12 @@ void CHDChain::Setup(const SecureString& securewords, const std::vector<uint8_t>
     vchSeed = SecureVector(hashWords.begin(), hashWords.end());
     id = GetSeedHash();
 }
+void CHDChain::SetupCrypted(const SecureVector& securewords, const SecureVector& secureseed) {
+    vchMnemonic = securewords;
+    vchSeed = secureseed;
+    // Seed/ID should be already set
+    //id = GetSeedHash();
+}
     
 bool CHDChain::GetMnemonic(SecureVector &vchMnemonicRet) const {
   // mnemonic was not set, fail

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -407,8 +407,8 @@ bool WalletInit::CheckIfWalletExists(const CChainParams &chainParams) {
         if (SanitizeString(walletFile, SAFE_CHARS_FILENAME) != walletFile) {
           return false;
         }
-
-        fs::path wallet_path = fs::absolute(walletFile, GetWalletDirNoCreate());
+        fs::path added_dir = BaseParams().DataDir();
+        fs::path wallet_path = fs::absolute(walletFile, GetWalletDirNoCreate(added_dir));
 
         if (fs::exists(wallet_path)) {
           return true;

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -34,7 +34,7 @@ public:
     bool Verify(const CChainParams &chainParams) override;
 
     //! Load wallet databases.
-    bool Open(const CChainParams &chainParams) override;
+    bool Open(const CChainParams &chainParams, const SecureString& walletPassphrase) override;
 
     //! Complete startup of wallets.
     void Start(CScheduler &scheduler) override;
@@ -82,11 +82,6 @@ std::string WalletInit::GetHelpString(bool showDebug) {
                        strprintf(_("Spend unconfirmed change when sending "
                                    "transactions (default: %d)"),
                                  DEFAULT_SPEND_ZEROCONF_CHANGE));
-    strUsage += HelpMessageOpt(
-        "-usehd",
-        _("Use hierarchical deterministic key generation (HD) after BIP32. "
-          "Only has effect during wallet creation/first start") +
-            " " + strprintf(_("(default: %d)"), DEFAULT_USE_HD_WALLET));
     strUsage += HelpMessageOpt("-upgradewallet",
                                _("Upgrade wallet to latest format on startup"));
     strUsage +=
@@ -383,7 +378,7 @@ bool WalletInit::Verify(const CChainParams &chainParams) {
     return true;
 }
 
-bool WalletInit::Open(const CChainParams &chainParams) {
+bool WalletInit::Open(const CChainParams &chainParams, const SecureString& walletPassphrase) {
     if (gArgs.GetBoolArg("-disablewallet", DEFAULT_DISABLE_WALLET)) {
         LogPrintf("Wallet disabled!\n");
         return true;
@@ -391,7 +386,7 @@ bool WalletInit::Open(const CChainParams &chainParams) {
 
     for (const std::string &walletFile : gArgs.GetArgs("-wallet")) {
         CWallet *const pwallet =
-            CWallet::CreateWalletFromFile(chainParams, walletFile);
+            CWallet::CreateWalletFromFile(chainParams, walletFile, walletPassphrase);
         if (!pwallet) {
             return false;
         }

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -805,9 +805,13 @@ UniValue dumpwallet(const Config &config, const JSONRPCRequest &request) {
     file << "\n";
 
     // add the base58check encoded extended master if the wallet uses HD
-    CHDChain hdChain = pwallet->GetHDChain();
+    CHDChain hdChain;
     SecureString ssMnemonic;
-    hdChain.GetMnemonic(ssMnemonic);
+    pwallet->GetHDChain(hdChain);
+     
+    if (!pwallet->GetMnemonic(hdChain, ssMnemonic))
+        throw std::runtime_error(std::string(__func__) + ": Get Mnemonic failed");
+      
     file << "# mnemonic: " << ssMnemonic << "\n";
 
     SecureVector vchSeed = hdChain.GetSeed();

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3068,7 +3068,8 @@ static UniValue getwalletinfo(const Config &config,
     LOCK2(cs_main, pwallet->cs_wallet);
 
     UniValue obj(UniValue::VOBJ);
-    CHDChain hdChain = pwallet->GetHDChain();
+    CHDChain hdChain;
+    pwallet->GetHDChain(hdChain);
 
     size_t kpExternalSize = pwallet->KeypoolCountExternalKeys();
     obj.pushKV("walletname", pwallet->GetName());

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -516,9 +516,7 @@ bool CWallet::SetMinVersion(enum WalletFeature nVersion, CWalletDB *pwalletdbIn,
     }
 
     CWalletDB *pwalletdb = pwalletdbIn ? pwalletdbIn : new CWalletDB(*dbw);
-    if (nWalletVersion > 40000) {
-        pwalletdb->WriteMinVersion(nWalletVersion);
-    }
+    pwalletdb->WriteMinVersion(nWalletVersion);
 
     if (!pwalletdbIn) {
         delete pwalletdb;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -397,14 +397,6 @@ bool CWallet::Unlock(const SecureString &strWalletPassphrase) {
   
     LOCK(cs_wallet);
     for (const MasterKeyMap::value_type &pMasterKey : mapMasterKeys) {
-      
-      std::cout << "\n\nUNLOCK Using Master Key";
-      std::cout << " vchCryptedKey = " << HexStr(pMasterKey.second.vchCryptedKey) << " ";
-      std::cout << " vchSalt = " << HexStr(pMasterKey.second.vchSalt);
-      std::cout << " iterations = " << pMasterKey.second.nDeriveIterations << "\n";
-      std::cout << " method = " << pMasterKey.second.nDerivationMethod << " and ";
-      std::cout << " with password = " << strWalletPassphrase << "\n";
-
         if (!crypter.SetKeyFromPassphrase(
                 strWalletPassphrase, pMasterKey.second.vchSalt,
                 pMasterKey.second.nDeriveIterations,
@@ -412,8 +404,7 @@ bool CWallet::Unlock(const SecureString &strWalletPassphrase) {
             return false;
         }
 
-      // Should get back original _vMasterKey....
-      
+        // Should get back original _vMasterKey....
         if (!crypter.Decrypt(pMasterKey.second.vchCryptedKey, _vMasterKey)) {
             // try another master key
             continue;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -393,6 +393,8 @@ bool CWallet::Unlock(const SecureString &strWalletPassphrase) {
     CCrypter crypter;
     CKeyingMaterial _vMasterKey;
 
+    if (!IsLocked()) return true;
+  
     LOCK(cs_wallet);
     for (const MasterKeyMap::value_type &pMasterKey : mapMasterKeys) {
       

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -40,7 +40,7 @@ extern std::vector<CWalletRef> vpwallets;
 extern CFeeRate payTxFee;
 extern bool bSpendZeroConfChange;
 
-static const unsigned int DEFAULT_KEYPOOL_SIZE = 1000;
+static const unsigned int DEFAULT_KEYPOOL_SIZE = 100;
 //! -paytxfee default
 static const Amount DEFAULT_TRANSACTION_FEE = Amount::zero();
 //! -fallbackfee default
@@ -59,8 +59,6 @@ static const bool DEFAULT_WALLET_REJECT_LONG_CHAINS = false;
 static const unsigned int MAX_FREE_TRANSACTION_CREATE_SIZE = 1000;
 static const bool DEFAULT_WALLETBROADCAST = true;
 static const bool DEFAULT_DISABLE_WALLET = false;
-//! if set, all keys will be derived by using BIP32
-static const bool DEFAULT_USE_HD_WALLET = true;
 
 extern const char *DEFAULT_WALLET_DAT;
 
@@ -1149,7 +1147,8 @@ public:
      * in case of an error.
      */
     static CWallet *CreateWalletFromFile(const CChainParams &chainParams,
-                                         const std::string walletFile);
+                                         const std::string walletFile,
+                                         const SecureString& walletPassphrase);
 
     /**
      * Wallet post-init setup
@@ -1162,7 +1161,6 @@ public:
 
     /* Set the HD chain model (chain child index counters) */
     bool SetHDChain(const CHDChain &chain, bool memonly);
-    const CHDChain &GetHDChain() { return hdChain; }
 
     /* Returns true if HD is enabled */
     bool IsHDEnabled();
@@ -1187,12 +1185,13 @@ public:
     //! Load metadata (used by LoadWallet)
     bool LoadKeyMetadata(const CTxDestination& pubKey, const CKeyMetadata &metadata);
 
-
-
-  bool HaveKey(const CKeyID &address) const override;
-  bool LoadHDPubKey(const CHDPubKey &hdPubKey);
-  bool AddHDPubKey(const CExtPubKey &extPubKey, bool fInternal);
-  bool AddKeyPubKeyX(const CKey& secret, const CPubKey &pubkey);
+    bool HaveKey(const CKeyID &address) const override;
+    bool LoadHDPubKey(const CHDPubKey &hdPubKey);
+    bool AddHDPubKey(const CExtPubKey &extPubKey, bool fInternal);
+    bool AddKeyPubKeyX(const CKey& secret, const CPubKey &pubkey);
+    bool SetCryptedHDChain(const CHDChain& chain, bool memonly);
+    bool GetDecryptedHDChain(CHDChain& hdChainRet);
+    bool GetMnemonic(CHDChain &hdChain, SecureString& securewords) const;
   
 };
 

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -515,6 +515,13 @@ bool ReadKeyValue(CWallet *pwallet, CDataStream &ssKey, CDataStream &ssValue,
                 strErr = "Error reading wallet database: SetHDChain failed";
                 return false;
             }
+        } else if (strType == "chdchain") {
+            CHDChain chain;
+            ssValue >> chain;
+            if (!pwallet->SetCryptedHDChain(chain, true)) {
+                strErr = "Error reading wallet database: SetHDCryptedChain failed";
+                return false;
+            }
         } else if (strType == "hdpubkey")  {
             CPubKey vchPubKey;
             ssKey >> vchPubKey;
@@ -926,4 +933,14 @@ bool CWalletDB::WriteHDPubKey(const CHDPubKey& hdPubKey, const CKeyMetadata& key
         return false;
 
   return WriteIC(std::make_pair(std::string("hdpubkey"), hdPubKey.extPubKey.pubkey), hdPubKey, false);
+}
+
+bool CWalletDB::WriteCryptedHDChain(const CHDChain& chain)
+{
+    if (!WriteIC(std::string("chdchain"), chain))
+        return false;
+
+    EraseIC(std::string("hdchain"));
+
+    return true;
 }

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -178,6 +178,7 @@ public:
 
     //! write the hdchain model (external chain child index counter)
     bool WriteHDChain(const CHDChain &chain);
+    bool WriteCryptedHDChain(const CHDChain& chain);
     bool WriteHDPubKey(const CHDPubKey& hdPubKey, const CKeyMetadata& keyMeta);
 
     //! Begin a new transaction

--- a/src/wallet/walletutil.cpp
+++ b/src/wallet/walletutil.cpp
@@ -25,7 +25,7 @@ fs::path GetWalletDir() {
 
     return path;
 }
-fs::path GetWalletDirNoCreate() {
+fs::path GetWalletDirNoCreate(fs::path& added_dir) {
   fs::path path;
   
   if (gArgs.IsArgSet("-walletdir")) {
@@ -37,6 +37,11 @@ fs::path GetWalletDirNoCreate() {
     }
   } else {
     path = GetDataDirNoCreate();
+    
+    if (added_dir != "") {
+      path /= added_dir;
+    }
+    
     // If a wallets directory exists, use that, otherwise default to
     // GetDataDir
     if (fs::is_directory(path / "wallets")) {

--- a/src/wallet/walletutil.cpp
+++ b/src/wallet/walletutil.cpp
@@ -16,11 +16,8 @@ fs::path GetWalletDir() {
         }
     } else {
         path = GetDataDir();
-        // If a wallets directory exists, use that, otherwise default to
-        // GetDataDir
-        if (fs::is_directory(path / "wallets")) {
-            path /= "wallets";
-        }
+        // Always use a wallets directory
+        path /= "wallets";
     }
 
     return path;
@@ -38,15 +35,13 @@ fs::path GetWalletDirNoCreate(fs::path& added_dir) {
   } else {
     path = GetDataDirNoCreate();
     
+    // This will be Net specific addition
     if (added_dir != "") {
       path /= added_dir;
     }
-    
-    // If a wallets directory exists, use that, otherwise default to
-    // GetDataDir
-    if (fs::is_directory(path / "wallets")) {
-      path /= "wallets";
-    }
+  
+    // Always assume a wallets directory
+    path /= "wallets";
   }
   
   return path;

--- a/src/wallet/walletutil.cpp
+++ b/src/wallet/walletutil.cpp
@@ -25,3 +25,24 @@ fs::path GetWalletDir() {
 
     return path;
 }
+fs::path GetWalletDirNoCreate() {
+  fs::path path;
+  
+  if (gArgs.IsArgSet("-walletdir")) {
+    path = gArgs.GetArg("-walletdir", "");
+    if (!fs::is_directory(path)) {
+      // If the path specified doesn't exist, we return the deliberately
+      // invalid empty string.
+      path = "";
+    }
+  } else {
+    path = GetDataDirNoCreate();
+    // If a wallets directory exists, use that, otherwise default to
+    // GetDataDir
+    if (fs::is_directory(path / "wallets")) {
+      path /= "wallets";
+    }
+  }
+  
+  return path;
+}

--- a/src/wallet/walletutil.h
+++ b/src/wallet/walletutil.h
@@ -9,6 +9,6 @@
 
 //! Get the path of the wallet directory.
 fs::path GetWalletDir();
-fs::path GetWalletDirNoCreate();
+fs::path GetWalletDirNoCreate(fs::path& added_dir);
 
 #endif // BITCOIN_WALLET_UTIL_H

--- a/src/wallet/walletutil.h
+++ b/src/wallet/walletutil.h
@@ -9,5 +9,6 @@
 
 //! Get the path of the wallet directory.
 fs::path GetWalletDir();
+fs::path GetWalletDirNoCreate();
 
 #endif // BITCOIN_WALLET_UTIL_H

--- a/src/walletinitinterface.h
+++ b/src/walletinitinterface.h
@@ -22,6 +22,8 @@ public:
     virtual void RegisterRPC(CRPCTable &) = 0;
     /** Verify wallets */
     virtual bool Verify(const CChainParams &chainParams) = 0;
+    /** Check if wallet exists already */
+    virtual bool CheckIfWalletExists(const CChainParams &chainParams) = 0;
     /** Open wallets*/
     virtual bool Open(const CChainParams &chainParams, const SecureString& walletPassphrase) = 0;
     /** Start wallets*/

--- a/src/walletinitinterface.h
+++ b/src/walletinitinterface.h
@@ -6,7 +6,7 @@
 #define WALLETINITINTERFACE_H
 
 #include "chainparams.h"
-
+#include "support/allocators/secure.h"
 #include <string>
 
 class CScheduler;
@@ -23,7 +23,7 @@ public:
     /** Verify wallets */
     virtual bool Verify(const CChainParams &chainParams) = 0;
     /** Open wallets*/
-    virtual bool Open(const CChainParams &chainParams) = 0;
+    virtual bool Open(const CChainParams &chainParams, const SecureString& walletPassphrase) = 0;
     /** Start wallets*/
     virtual void Start(CScheduler &scheduler) = 0;
     /** Flush Wallets*/


### PR DESCRIPTION
Requires setting password for Wallet on 1st run if no wallet exists
  For both 'devaultd' and 'devault-qt'

Allow encrypting unencrypted wallet
Allows previously unencrypted wallet to still exist
Reduced KEYPOOL size from 1000 to 100 to speed up first run