### PR TITLE
Hd cleanup

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1113,18 +1113,15 @@ bool BitcoinGUI::handlePaymentRequest(const SendCoinsRecipient &recipient) {
     return false;
 }
 
-void BitcoinGUI::setHDStatus(int hdEnabled) {
+void BitcoinGUI::setHDStatus() {
     labelWalletHDStatusIcon->setPixmap(
         platformStyle
-            ->SingleColorIcon(hdEnabled ? ":/icons/hd_enabled"
-                                        : ":/icons/hd_disabled")
+            ->SingleColorIcon(":/icons/hd_enabled")
             .pixmap(STATUSBAR_ICONSIZE, STATUSBAR_ICONSIZE));
-    labelWalletHDStatusIcon->setToolTip(
-        hdEnabled ? tr("HD key generation is <b>enabled</b>")
-                  : tr("HD key generation is <b>disabled</b>"));
+    labelWalletHDStatusIcon->setToolTip(tr("HD key generation is <b>enabled</b>"));;
 
     // eventually disable the QLabel to set its opacity to 50%
-    labelWalletHDStatusIcon->setEnabled(hdEnabled);
+    labelWalletHDStatusIcon->setEnabled(true);
 }
 
 void BitcoinGUI::setEncryptionStatus(int status) {
@@ -1164,7 +1161,7 @@ void BitcoinGUI::updateWalletStatus() {
     }
     WalletModel *const walletModel = walletView->getWalletModel();
     setEncryptionStatus(walletModel->getEncryptionStatus());
-    setHDStatus(walletModel->hdEnabled());
+    setHDStatus();
 }
 #endif // ENABLE_WALLET
 

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -209,10 +209,9 @@ private:
     void setEncryptionStatus(int status);
 
     /** Set the hd-enabled status as shown in the UI.
-     @param[in] status            current hd enabled status
      @see WalletModel::EncryptionStatus
      */
-    void setHDStatus(int hdEnabled);
+    void setHDStatus();
 
 public Q_SLOTS:
     bool handlePaymentRequest(const SendCoinsRecipient &recipient);

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -592,10 +592,6 @@ bool WalletModel::isWalletEnabled() {
     return !gArgs.GetBoolArg("-disablewallet", DEFAULT_DISABLE_WALLET);
 }
 
-bool WalletModel::hdEnabled() const {
-    return wallet->IsHDEnabled();
-}
-
 QString WalletModel::getWalletName() const {
     LOCK(wallet->cs_wallet);
     return QString::fromStdString(wallet->GetName());

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -209,8 +209,6 @@ public:
 
     static bool isWalletEnabled();
 
-    bool hdEnabled() const;
-
     const CChainParams &getChainParams() const;
 
     QString getWalletName() const;

--- a/src/wallet/crypter.cpp
+++ b/src/wallet/crypter.cpp
@@ -351,6 +351,10 @@ std::set<CKeyID> CCryptoKeyStore::GetKeys() const {
     return set_address;
 }
 
+// Since this only happens during wallet encryption then there
+// will be no MapKeys to encrypt since all keys will be HD keys
+// MapKeys are for imported private keys
+// Now just use SetCrypted instead - keep this for a bit
 bool CCryptoKeyStore::EncryptKeys(CKeyingMaterial &vMasterKeyIn) {
     {
         LOCK(cs_KeyStore);
@@ -379,9 +383,7 @@ bool CCryptoKeyStore::EncryptKeys(CKeyingMaterial &vMasterKeyIn) {
 
 bool CCryptoKeyStore::EncryptHDChain(const CKeyingMaterial& vMasterKeyIn)
 {
-    // should call EncryptKeys first
-    if (!IsCrypted())
-        return false;
+    SetCrypted();
 
     if (!cryptedHDChain.IsNull())
         return true;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -219,7 +219,7 @@ void CWallet::DeriveNewChildKey(CWalletDB &walletdb, CKeyMetadata &metadata,
       throw std::runtime_error(std::string(__func__) + ": SetCryptedHDChain failed");
   }
   else {
-    if (!SetHDChain(hdChainCurrent, false))
+    if (!SetHDChain(hdChainCurrent))
       throw std::runtime_error(std::string(__func__) + ": SetHDChain failed");
   }
  
@@ -691,6 +691,7 @@ bool CWallet::EncryptHDWallet(const CKeyingMaterial& _vMasterKey) {
         }
       
   }
+  return true;
 }
 
 bool CWallet::FinishEncryptWallet(const SecureString &strWalletPassphrase) {
@@ -1564,7 +1565,7 @@ void CWallet::GenerateHDMasterKey() {
   
   hdChain.Setup(words, hashWords);
   // Store to dB
-  SetHDChain(hdChain, false);
+  SetHDChain(hdChain);
 }
 
 // Need to Review
@@ -1573,16 +1574,11 @@ CPubKey CWallet::GenerateNewHDMasterKey() {
   return pubkey;
 }
 
-bool CWallet::SetHDChain(const CHDChain &chain, bool memonly) {
+bool CWallet::SetHDChain(const CHDChain &chain) {
     LOCK(cs_wallet);
   
     if (!CCryptoKeyStore::SetHDChain(chain))
       return false;
-
-    if (!memonly && !CWalletDB(*dbw).WriteHDChain(chain)) {
-        throw std::runtime_error(std::string(__func__) +
-                                 ": writing chain failed");
-    }
 
     hdChain = chain;
     return true;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1584,10 +1584,6 @@ bool CWallet::SetHDChain(const CHDChain &chain) {
     return true;
 }
 
-bool CWallet::IsHDEnabled() {
-  return true;//!hdChain.masterKeyID.IsNull();
-}
-
 int64_t CWalletTx::GetTxTime() const {
     int64_t n = nTimeSmart;
     return n ? n : nTimeReceived;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1163,7 +1163,7 @@ public:
     bool BackupWallet(const std::string &strDest);
 
     /* Set the HD chain model (chain child index counters) */
-    bool SetHDChain(const CHDChain &chain, bool memonly);
+    bool SetHDChain(const CHDChain &chain);
 
     /* Returns true if HD is enabled */
     bool IsHDEnabled();

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1165,9 +1165,6 @@ public:
     /* Set the HD chain model (chain child index counters) */
     bool SetHDChain(const CHDChain &chain);
 
-    /* Returns true if HD is enabled */
-    bool IsHDEnabled();
-
    /* Generates a new HD master key (will not be activated) */
     void GenerateHDMasterKey();
     CPubKey GenerateNewHDMasterKey();

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -914,7 +914,10 @@ public:
     bool Unlock(const SecureString &strWalletPassphrase);
     bool ChangeWalletPassphrase(const SecureString &strOldWalletPassphrase,
                                 const SecureString &strNewWalletPassphrase);
-    bool EncryptWallet(const SecureString &strWalletPassphrase);
+    bool EncryptHDWallet(const CKeyingMaterial& _vMasterKey);
+    bool FinishEncryptWallet(const SecureString &strWalletPassphrase);
+    bool CreateMasteyKey(const SecureString &strWalletPassphrase,
+                         CKeyingMaterial& _vMasterKey);
 
     void GetKeyBirthTimes(std::map<CTxDestination, int64_t> &mapKeyBirth) const;
     unsigned int ComputeTimeSmart(const CWalletTx &wtx) const;

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -508,13 +508,6 @@ bool ReadKeyValue(CWallet *pwallet, CDataStream &ssKey, CDataStream &ssValue,
                 strErr = "Error reading wallet database: LoadDestData failed";
                 return false;
             }
-        } else if (strType == "hdchain") {
-            CHDChain chain;
-            ssValue >> chain;
-            if (!pwallet->SetHDChain(chain, true)) {
-                strErr = "Error reading wallet database: SetHDChain failed";
-                return false;
-            }
         } else if (strType == "chdchain") {
             CHDChain chain;
             ssValue >> chain;
@@ -548,8 +541,7 @@ bool ReadKeyValue(CWallet *pwallet, CDataStream &ssKey, CDataStream &ssValue,
 
 bool CWalletDB::IsKeyType(const std::string &strType) {
     return (strType == "key" || strType == "wkey" || strType == "mkey" ||
-            strType == "hdchain" || 
-            strType == "chdchain" || 
+            strType == "chdchain" ||
             strType == "ckey");
 }
 
@@ -854,7 +846,7 @@ bool CWalletDB::RecoverKeysOnlyFilter(void *callbackData, CDataStream ssKey,
         fReadOK = ReadKeyValue(dummyWallet, ssKey, ssValue, dummyWss, strType,
                                strErr);
     }
-    if (!IsKeyType(strType) && strType != "hdchain") {
+    if (!IsKeyType(strType) && strType != "hdpubkey") {
         return false;
     }
     if (!fReadOK) {
@@ -903,10 +895,6 @@ bool CWalletDB::EraseDestData(const CTxDestination &address,
         std::make_pair(EncodeCashAddr(address, Params()), key)));
 }
 
-bool CWalletDB::WriteHDChain(const CHDChain &chain) {
-    return WriteIC(std::string("hdchain"), chain);
-}
-
 bool CWalletDB::TxnBegin() {
     return batch.TxnBegin();
 }
@@ -939,8 +927,6 @@ bool CWalletDB::WriteCryptedHDChain(const CHDChain& chain)
 {
     if (!WriteIC(std::string("chdchain"), chain))
         return false;
-
-    EraseIC(std::string("hdchain"));
 
     return true;
 }

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -177,7 +177,6 @@ public:
                                    std::string &errorStr);
 
     //! write the hdchain model (external chain child index counter)
-    bool WriteHDChain(const CHDChain &chain);
     bool WriteCryptedHDChain(const CHDChain& chain);
     bool WriteHDPubKey(const CHDPubKey& hdPubKey, const CKeyMetadata& keyMeta);
 


### PR DESCRIPTION
No longer allow writing unencrypted HDchain to database

Let me know if this seems to speed up initial wallet creation. I think I saved several hdchain writes that were going to the DB before
