### PR TITLE
Rename debug.log from last run to use debug  + timestamp last accesse…

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -406,7 +406,7 @@ std::string HelpMessage(HelpMessageMode mode) {
     strUsage += HelpMessageOpt(
                              "-keeplogfiles=<days>",
                              strprintf(
-                                       _("If specified, debug log file older than <days> days will be deleted where days must be 1 or more, otherwise log files older than 1 day will be deleted")));
+                                       _("If specified, debug log file older than <days> days will be deleted where days must be 1 or more, otherwise log files older than %d days will be deleted"), DEFAULT_DEBUGLOGFILE_KEEPDAYS));
 
     strUsage += HelpMessageOpt(
         "-maxorphantx=<n>", strprintf(_("Keep at most <n> unconnectable "

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -7,9 +7,9 @@
 #include "logging.h"
 #include "util.h"
 #include "utiltime.h"
+#include <chrono>
 
 bool fLogIPs = DEFAULT_LOGIPS;
-const char *const DEFAULT_DEBUGLOGFILE = "debug.log";
 
 /**
  * NOTE: the logger instance is leaked on exit. This is ugly, but will be
@@ -32,6 +32,7 @@ BCLog::Logger &GetLogger() {
 static int FileWriteStr(const std::string &str, FILE *fp) {
     return fwrite(str.data(), 1, str.size(), fp);
 }
+
 
 fs::path BCLog::Logger::GetDebugLogPath() {
     fs::path logfile(gArgs.GetArg("-debuglogfile", DEFAULT_DEBUGLOGFILE));
@@ -224,6 +225,44 @@ void BCLog::Logger::ShrinkDebugFile() {
         }
     } else if (file != nullptr) {
         fclose(file);
+    }
+}
+
+std::string BCLog::Logger::RenameLastDebugFile(){
+  fs::path pathLog = GetDataDir();
+  pathLog /= DEFAULT_DEBUGLOGFILE;
+  fs::path oldLog = GetDataDir();
+  if (fs::exists(pathLog)) {
+    auto last_write_time = fs::last_write_time(pathLog);
+    std::string s = "debug-"+FormatISO8601DateTime(last_write_time)+".log";
+    oldLog /= s;
+    fs::rename(pathLog, oldLog);
+    return oldLog.c_str();
+  }
+  return "";
+}
+
+//! Remove debug.log files older than 1 day unless "keeplogfiles" is specified
+//  then keep up to days specified by argument
+void BCLog::Logger::RemoveOlderDebugFiles() {
+    int days_to_keep = gArgs.GetArg("-keeplogfiles", 1);
+    days_to_keep = std::max(1, days_to_keep);
+    fs::path pathLog = GetDataDir();
+    fs::directory_iterator dir_it(pathLog);
+    for(const auto& it : dir_it) {
+        if (!fs::is_regular_file(it.status())) continue;
+        std::string filename = it.path().filename().c_str();
+        std::size_t found_log = filename.find(".log");
+        std::size_t found_debug = filename.find("debug");
+        if (found_log !=std::string::npos && found_debug != std::string::npos) {
+            //LogPrintf("Found older debug file %s\n",it.path().filename().c_str());
+            auto last_write_time = fs::last_write_time(it.path());
+            std::time_t cftime = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+            if ((cftime - last_write_time) > (60*60*24*days_to_keep)) {
+                LogPrintf("Removing %s since older than %d day",it.path().filename().c_str(),days_to_keep);
+                fs::remove(it.path().filename());
+            }
+        }
     }
 }
 

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -243,9 +243,9 @@ std::string BCLog::Logger::RenameLastDebugFile(){
 }
 
 //! Remove debug.log files older than 1 day unless "keeplogfiles" is specified
-//  then keep up to days specified by argument
+//  then keep up to days specified by argument with a minimum of 1
 void BCLog::Logger::RemoveOlderDebugFiles() {
-    int days_to_keep = gArgs.GetArg("-keeplogfiles", 1);
+    int days_to_keep = gArgs.GetArg("-keeplogfiles", DEFAULT_DEBUGLOGFILE_KEEPDAYS);
     days_to_keep = std::max(1, days_to_keep);
     fs::path pathLog = GetDataDir();
     fs::directory_iterator dir_it(pathLog);
@@ -255,11 +255,10 @@ void BCLog::Logger::RemoveOlderDebugFiles() {
         std::size_t found_log = filename.find(".log");
         std::size_t found_debug = filename.find("debug");
         if (found_log !=std::string::npos && found_debug != std::string::npos) {
-            //LogPrintf("Found older debug file %s\n",it.path().filename().c_str());
             auto last_write_time = fs::last_write_time(it.path());
             std::time_t cftime = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
             if ((cftime - last_write_time) > (60*60*24*days_to_keep)) {
-                LogPrintf("Removing %s since older than %d day",it.path().filename().string(),days_to_keep);
+                LogPrintf("Removing %s since older than %d day\n",it.path().filename().string(),days_to_keep);
                 fs::remove(it.path().filename());
             }
         }

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -237,7 +237,7 @@ std::string BCLog::Logger::RenameLastDebugFile(){
     std::string s = "debug-"+FormatISO8601DateTime(last_write_time)+".log";
     oldLog /= s;
     fs::rename(pathLog, oldLog);
-    return oldLog.c_str();
+    return oldLog.string();
   }
   return "";
 }
@@ -251,7 +251,7 @@ void BCLog::Logger::RemoveOlderDebugFiles() {
     fs::directory_iterator dir_it(pathLog);
     for(const auto& it : dir_it) {
         if (!fs::is_regular_file(it.status())) continue;
-        std::string filename = it.path().filename().c_str();
+        std::string filename = it.path().filename().string();
         std::size_t found_log = filename.find(".log");
         std::size_t found_debug = filename.find("debug");
         if (found_log !=std::string::npos && found_debug != std::string::npos) {
@@ -259,7 +259,7 @@ void BCLog::Logger::RemoveOlderDebugFiles() {
             auto last_write_time = fs::last_write_time(it.path());
             std::time_t cftime = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
             if ((cftime - last_write_time) > (60*60*24*days_to_keep)) {
-                LogPrintf("Removing %s since older than %d day",it.path().filename().c_str(),days_to_keep);
+                LogPrintf("Removing %s since older than %d day",it.path().filename().string(),days_to_keep);
                 fs::remove(it.path().filename());
             }
         }

--- a/src/logging.h
+++ b/src/logging.h
@@ -20,7 +20,9 @@ static const bool DEFAULT_LOGTIMEMICROS = false;
 static const bool DEFAULT_LOGIPS = false;
 static const bool DEFAULT_LOGTIMESTAMPS = true;
 
+// For debug.log log files, used in init and logging.cpp
 static const std::string DEFAULT_DEBUGLOGFILE = "debug.log";
+static const uint32_t DEFAULT_DEBUGLOGFILE_KEEPDAYS = 7;
 
 extern bool fLogIPs;
 

--- a/src/logging.h
+++ b/src/logging.h
@@ -20,8 +20,9 @@ static const bool DEFAULT_LOGTIMEMICROS = false;
 static const bool DEFAULT_LOGIPS = false;
 static const bool DEFAULT_LOGTIMESTAMPS = true;
 
+static const std::string DEFAULT_DEBUGLOGFILE = "debug.log";
+
 extern bool fLogIPs;
-extern const char *const DEFAULT_DEBUGLOGFILE;
 
 namespace BCLog {
 
@@ -89,6 +90,9 @@ public:
     fs::path GetDebugLogPath();
     bool OpenDebugLog();
     void ShrinkDebugFile();
+    std::string RenameLastDebugFile();
+    void RemoveOlderDebugFiles();
+
 
     void EnableCategory(LogFlags category);
     bool EnableCategory(const std::string &str);


### PR DESCRIPTION
…d, keep old logs 1 day unless overriden with keeplogfiles= option