### PR TITLE
Change  DEFAULT_MAX_REORG_DEPTH to 30 from 10

### DIFF
--- a/src/validation.h
+++ b/src/validation.h
@@ -200,7 +200,7 @@ static const bool DEFAULT_PEERBLOOMFILTERS = true;
 /** Default for -stopatheight */
 static const int DEFAULT_STOPATHEIGHT = 0;
 /** Default for -maxreorgdepth */
-static const int DEFAULT_MAX_REORG_DEPTH = 50;
+static const int DEFAULT_MAX_REORG_DEPTH = 30;
 /**
  * Default for -finalizationdelay
  * This is the minimum time between a block header reception and the block

--- a/src/validation.h
+++ b/src/validation.h
@@ -200,7 +200,7 @@ static const bool DEFAULT_PEERBLOOMFILTERS = true;
 /** Default for -stopatheight */
 static const int DEFAULT_STOPATHEIGHT = 0;
 /** Default for -maxreorgdepth */
-static const int DEFAULT_MAX_REORG_DEPTH = 10;
+static const int DEFAULT_MAX_REORG_DEPTH = 50;
 /**
  * Default for -finalizationdelay
  * This is the minimum time between a block header reception and the block


### PR DESCRIPTION
Tentatively setting to 50 to give more leeway since ABC blocks are 5 times slower than ours.
If you don't agree, let's discuss. 10 seems too small, but 30 would work too IMO (1 hour duration)

