### PR TITLE
Fix GCC 8 warnings

### DIFF
--- a/src/prevector.h
+++ b/src/prevector.h
@@ -304,7 +304,7 @@ private:
             // The most common use of prevector is where T=uint8_t. For
             // trivially constructible types, we can use memset() to avoid
             // looping.
-            ::memset(dst, 0, count * sizeof(T));
+            ::memset((void*)dst, 0, count * sizeof(T));
         } else {
             for (auto i = 0; i < count; ++i) {
                 new (static_cast<void *>(dst + i)) T();

--- a/src/seeder/bitcoin.cpp
+++ b/src/seeder/bitcoin.cpp
@@ -299,8 +299,11 @@ public:
                                         sock != INVALID_SOCKET) {
             char pchBuf[0x10000];
             fd_set set;
+            fd_set set2;
             FD_ZERO(&set);
+            FD_ZERO(&set2);
             FD_SET(sock, &set);
+            FD_SET(sock, &set2);
             struct timeval wa;
             if (doneAfter) {
                 wa.tv_sec = doneAfter - now;
@@ -309,7 +312,7 @@ public:
                 wa.tv_sec = GetTimeout();
                 wa.tv_usec = 0;
             }
-            int ret = select(sock + 1, &set, nullptr, &set, &wa);
+            int ret = select(sock + 1, &set2, nullptr, &set, &wa);
             if (ret != 1) {
                 if (!doneAfter) res = false;
                 break;


### PR DESCRIPTION
These changes fix two annoying warnings for GCC 8. Casting void is also in the official documentation for suppressing -Wclass-memaccess afaik