### PR TITLE
Dont set wallet locked if using bypasspassword option and password is…

### DIFF
--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -11,6 +11,7 @@
 #include <recentrequeststablemodel.h>
 #include <transactiontablemodel.h>
 
+#include <init.h> // for BypassPassword
 #include <config.h>
 #include <dstencode.h>
 #include <keystore.h>
@@ -292,6 +293,8 @@ WalletModel::WalletStatus WalletModel::getWalletStatus() const {
 }
 
 bool WalletModel::setWalletLocked(bool locked, const SecureString &passPhrase) {
+    // must set -bypsasword and already have that password
+    if (gArgs.GetBoolArg("-bypasspassword", false) && passPhrase == BypassPassword) return true;
     if (locked) {
         // Lock
         return m_wallet->lock();

--- a/src/wallet/crypter.cpp
+++ b/src/wallet/crypter.cpp
@@ -192,7 +192,7 @@ bool CCryptoKeyStore::Lock() {
 
     {
         LOCK(cs_KeyStore);
-        vMasterKey.clear();
+        if (!gArgs.GetBoolArg("-bypasspassword",false))  vMasterKey.clear();
     }
 
     NotifyStatusChanged(this);


### PR DESCRIPTION
… the default value, dont clear vMasterKey if -bypasspassword set

This is so the QT wallet can be used if the wallet was initially setup with -bypasspassword
