### PR TITLE
Cancel operations in validation when progress dialog is closed

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -118,6 +118,16 @@ bool ShutdownRequested() {
     return fRequestShutdown;
 }
 
+std::atomic<bool> fRequestStopDialog(false);
+
+void StopDialog() {
+    fRequestStopDialog = true;
+}
+
+bool StopDialogRequested() {
+    return fRequestStopDialog;
+}
+
 /**
  * This is a minimally invasive approach to shutdown on LevelDB read errors from
  * the chainstate, while keeping user interface out of the common library, which

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -120,6 +120,10 @@ bool ShutdownRequested() {
 
 std::atomic<bool> fRequestStopDialog(false);
 
+void StartDialog() {
+    fRequestStopDialog = false;
+}
+
 void StopDialog() {
     fRequestStopDialog = true;
 }

--- a/src/init.h
+++ b/src/init.h
@@ -27,6 +27,8 @@ class thread_group;
 
 void StartShutdown();
 bool ShutdownRequested();
+void StopDialog();
+bool StopDialogRequested();
 /** Interrupt threads */
 void Interrupt();
 /** Interrupt all script checking threads once they're out of work */

--- a/src/init.h
+++ b/src/init.h
@@ -27,6 +27,7 @@ class thread_group;
 
 void StartShutdown();
 bool ShutdownRequested();
+void StartDialog();
 void StopDialog();
 bool StopDialogRequested();
 /** Interrupt threads */

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1225,10 +1225,16 @@ void BitcoinGUI::detectShutdown() {
         qApp->quit();
     }
 }
+// Called when showProgress is cancelled - not using thread stuff for StopDialog
+void BitcoinGUI::cancel() {
+   disconnect(progressDialog, &QProgressDialog::canceled, this, &BitcoinGUI::cancel);
+   StopDialog();
+}
 
 void BitcoinGUI::showProgress(const QString &title, int nProgress) {
     if (nProgress == 0) {
         progressDialog = new QProgressDialog(title, "", 0, 100);
+        connect(progressDialog, &QProgressDialog::canceled, this, &BitcoinGUI::cancel);
         progressDialog->setWindowModality(Qt::ApplicationModal);
         progressDialog->setMinimumDuration(0);
         progressDialog->setCancelButton(nullptr);

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1240,8 +1240,10 @@ void BitcoinGUI::showProgress(const QString &title, int nProgress) {
         progressDialog->setCancelButton(nullptr);
         progressDialog->setAutoClose(false);
         progressDialog->setValue(0);
+        StartDialog();
     } else if (progressDialog) {
         if (nProgress == 100) {
+            disconnect(progressDialog, &QProgressDialog::canceled, this, &BitcoinGUI::cancel);
             progressDialog->close();
             progressDialog->deleteLater();
         } else {

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -83,6 +83,7 @@ public:
      */
     bool addWallet(WalletModel *walletModel);
     void removeAllWallets();
+    void cancel();
     bool enableWallet = false;
 
 protected:

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4570,8 +4570,8 @@ bool CVerifyDB::VerifyDB(const Config &config, CCoinsView *coinsview,
     LogPrintf("[0%%]...");
     for (CBlockIndex *pindex = chainActive.Tip(); pindex && pindex->pprev;
          pindex = pindex->pprev) {
-        interruption_point(ShutdownRequested());
         if (StopDialogRequested()) break;
+        interruption_point(ShutdownRequested());
         int percentageDone = std::max(1, std::min(99,
                                                   (int)(((double)(chainActive.Height() - pindex->nHeight)) /
                                                         (double)nCheckDepth * (nCheckLevel >= 4 ? 50 : 100))));
@@ -4660,8 +4660,8 @@ bool CVerifyDB::VerifyDB(const Config &config, CCoinsView *coinsview,
     if (nCheckLevel >= 4) {
         CBlockIndex *pindex = pindexState;
         while (pindex != chainActive.Tip()) {
-            interruption_point(ShutdownRequested());
             if (StopDialogRequested()) break;
+            interruption_point(ShutdownRequested());
 
             uiInterface.ShowProgress(
                 _("Verifying blocks..."),

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4571,6 +4571,7 @@ bool CVerifyDB::VerifyDB(const Config &config, CCoinsView *coinsview,
     for (CBlockIndex *pindex = chainActive.Tip(); pindex && pindex->pprev;
          pindex = pindex->pprev) {
         interruption_point(ShutdownRequested());
+        if (StopDialogRequested()) break;
         int percentageDone = std::max(1, std::min(99,
                                                   (int)(((double)(chainActive.Height() - pindex->nHeight)) /
                                                         (double)nCheckDepth * (nCheckLevel >= 4 ? 50 : 100))));
@@ -4660,6 +4661,8 @@ bool CVerifyDB::VerifyDB(const Config &config, CCoinsView *coinsview,
         CBlockIndex *pindex = pindexState;
         while (pindex != chainActive.Tip()) {
             interruption_point(ShutdownRequested());
+            if (StopDialogRequested()) break;
+
             uiInterface.ShowProgress(
                 _("Verifying blocks..."),
                 std::max(

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1669,7 +1669,8 @@ CBlockIndex *CWallet::ScanForWalletTransactions(
                 LogPrintf("Still rescanning. At block %d. Progress=%f\n",
                           pindex->nHeight, gvp);
             }
-
+            if (StopDialogRequested()) AbortRescan();
+          
             CBlock block;
             if (ReadBlockFromDisk(block, pindex, GetConfig())) {
                 LOCK2(cs_main, cs_wallet);


### PR DESCRIPTION
Previously closing the dialog would just make it pop up again and continue, making the operation impossible to cancel. This just changes verifychain at the moment. Will look at other cases that may benefit