### PR TITLE
Generate Random Keys for BLS transaction outputs deterministically

### DIFF
--- a/src/key.h
+++ b/src/key.h
@@ -81,6 +81,10 @@ public:
     //! Generate a new private BLS key using a cryptographic PRNG.
     void MakeNewBLSKey();
 
+    //! Generate a new private BLS key using a deterministic source
+    void MakeNewDeterministicBLSKey(const std::vector<uint8_t>& hash);
+    CPrivKey GetBLSPrivateKey() const;
+
     /**
      * Compute the public key from a private key.
      * This is expensive.

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -5714,7 +5714,14 @@ CHDPubKey CWallet::AddHDPubKeyWithoutDB(const CExtPubKey &extPubKey, bool fInter
     
     return hdPubKey;
   }
-  
+
+bool CWallet::WriteBLSRandomKey(const CKey &key) const {
+  auto nID = key.GetPubKeyForBLS();
+  if (!WalletBatch(*database).WriteRandomKey(nID, key.GetBLSPrivateKey())) {
+      throw std::runtime_error(std::string(__func__) + ": WriteRandomKey failed");
+    }
+    return true;
+}
 
 bool CWallet::StoreCryptedHDChain(const CHDChain& chain) {
     LOCK(cs_wallet);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1407,6 +1407,7 @@ public:
     bool SetCryptedHDChain(const CHDChain& chain);
     bool StoreCryptedHDChain(const CHDChain& chain);
     bool StoreCryptedHDChain();
+    bool WriteBLSRandomKey(const CKey &key) const;
     bool GetMnemonic(CHDChain &hdChain, SecureString& securewords) const;
     SecureVector getWords() const;
   

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -82,6 +82,10 @@ bool WalletBatch::WriteMasterKey(unsigned int nID, const CMasterKey &kMasterKey)
     return WriteIC(std::make_pair(std::string("mkey"), nID), kMasterKey, true);
 }
 
+bool WalletBatch::WriteRandomKey(const CPubKey &pubk, const CPrivKey &kRandomKey) {
+    return WriteIC(std::make_pair(std::string("rkey"), pubk), kRandomKey, true);
+}
+
 bool WalletBatch::WriteCScript(const uint160 &hash, const CScript &redeemScript) {
     return WriteIC(std::make_pair(std::string("cscript"), hash), redeemScript,
                    false);

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -109,6 +109,7 @@ public:
     bool EraseTx(uint256 hash);
 
     bool WriteMasterKey(unsigned int nID, const CMasterKey &kMasterKey);
+    bool WriteRandomKey(const CPubKey& nID, const CPrivKey &kRandomKey);
 
     bool WriteCScript(const uint160 &hash, const CScript &redeemScript);
 


### PR DESCRIPTION
and store to wallet DB. This can be used in the future to prove that you created a BLS Tx output. Since inputs and outputs are unlinked and transactions will be aggregated, a Tx ID itself will not be sufficient to show that one has created an output. Instead one should show a signature for the random key used for a Tx output as only the Sender will know the private key for that.
